### PR TITLE
(feat): increase touch target for settings icon

### DIFF
--- a/core/lib/src/components/scaffolds/lmu_scaffold.dart
+++ b/core/lib/src/components/scaffolds/lmu_scaffold.dart
@@ -6,7 +6,6 @@ import 'package:core/src/components/scaffolds/sliver_app_bar_delegate.dart';
 import 'package:core/themes.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:snap_scroll_physics/snap_scroll_physics.dart';
 
 class LmuScaffold extends StatefulWidget {
   const LmuScaffold({
@@ -42,8 +41,6 @@ class _LmuScaffoldState extends State<LmuScaffold> {
   String get _largeTitle => _appBar.largeTitle ?? ' ';
   double get _collapsedTitleHeight =>
       widget.isBottomSheet ? _bottomeSheetCollapsedTitleHeight : _defaultCollapsedTitleHeight;
-
-  bool get _hasImage => _appBar.imageUrls != null && _appBar.imageUrls!.isNotEmpty;
 
   @override
   void initState() {
@@ -81,11 +78,7 @@ class _LmuScaffoldState extends State<LmuScaffold> {
             mainAxisMargin: widget.isBottomSheet ? _bottomeSheetCollapsedTitleHeight : 3,
             child: CustomScrollView(
               controller: _scrollController,
-              physics: SnapScrollPhysics.preventStopBetween(
-                0,
-                calculatedLargeTitleHeight + (_hasImage ? 180 : 0),
-                parent: const AlwaysScrollableScrollPhysics(),
-              ),
+              physics: const AlwaysScrollableScrollPhysics(),
               slivers: [
                 SliverPersistentHeader(
                   pinned: true,

--- a/feature_modules/home/lib/src/pages/home_page.dart
+++ b/feature_modules/home/lib/src/pages/home_page.dart
@@ -19,8 +19,15 @@ class HomePage extends StatelessWidget {
       appBar: LmuAppBarData(
         largeTitle: "Home",
         largeTitleTrailingWidget: GestureDetector(
+          behavior: HitTestBehavior.translucent,
           onTap: () => GetIt.I.get<SettingsService>().navigateToSettings(context),
-          child: const LmuIcon(icon: LucideIcons.settings, size: LmuIconSizes.medium),
+          child: const Padding(
+            padding: EdgeInsets.only(left: LmuSizes.size_16),
+            child: SizedBox(
+              height: 40,
+              child: LmuIcon(icon: LucideIcons.settings, size: LmuIconSizes.medium),
+            ),
+          ),
         ),
       ),
       body: BlocBuilder<HomeCubit, HomeState>(


### PR DESCRIPTION
Increase the touch target of the setting icon to 40x40. 

<img width="250px" src="https://github.com/user-attachments/assets/43135858-c6d5-463c-b15c-f5462a50ea08">
