### PR TITLE
(chore): migrate wishlist requests to new endpoint v2

### DIFF
--- a/feature_modules/benefits/lib/src/infrastructure/secondary/data/storage/benefits_storage.dart
+++ b/feature_modules/benefits/lib/src/infrastructure/secondary/data/storage/benefits_storage.dart
@@ -27,8 +27,12 @@ class BenefitsStorage {
       return null;
     }
 
-    final benefitsMap = jsonDecode(benefitsJson) as Map<String, dynamic>;
-    return BenefitsDto.fromJson(benefitsMap);
+    try {
+      final benefitsMap = jsonDecode(benefitsJson) as Map<String, dynamic>;
+      return BenefitsDto.fromJson(benefitsMap);
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<void> deleteBenefits() async {

--- a/feature_modules/wishlist/lib/src/pages/wishlist_details_page.dart
+++ b/feature_modules/wishlist/lib/src/pages/wishlist_details_page.dart
@@ -22,10 +22,12 @@ class WishlistDetailsPage extends StatelessWidget {
   final WishlistModel wishlistModel;
 
   Future<void> _launchPrototype(BuildContext context) async {
-    if (await LmuUrlLauncher.canLaunch(url: wishlistModel.prototypeUrl)) {
+    final url = wishlistModel.prototypeUrl;
+    if (url == null || url.isEmpty) return;
+    if (await LmuUrlLauncher.canLaunch(url: url)) {
       if (context.mounted) {
         LmuUrlLauncher.launchWebsite(
-          url: wishlistModel.prototypeUrl,
+          url: url,
           context: context,
           mode: LmuUrlLauncherMode.inAppWebView,
         ).whenComplete(
@@ -115,13 +117,13 @@ class WishlistDetailsPage extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: LmuSizes.size_16),
             child: LmuText.body(
-              wishlistModel.description,
+              wishlistModel.content,
               color: context.colors.neutralColors.textColors.mediumColors.base,
             ),
           ),
           const SizedBox(height: LmuSizes.size_24),
           ImageListSection(imageModels: wishlistModel.imageModels),
-          if (wishlistModel.prototypeUrl.isNotEmpty)
+          if (wishlistModel.prototypeUrl?.isNotEmpty ?? false)
             Padding(
               padding: const EdgeInsets.only(
                 top: LmuSizes.size_24,

--- a/feature_modules/wishlist/lib/src/repository/api/models/wishlist_model.dart
+++ b/feature_modules/wishlist/lib/src/repository/api/models/wishlist_model.dart
@@ -8,36 +8,32 @@ part 'wishlist_model.g.dart';
 
 @JsonSerializable()
 class WishlistModel extends RWishlistModel {
-  final int id;
+  final String id;
   final String title;
   final String description;
-  @JsonKey(name: 'description_short')
-  final String descriptionShort;
+  final String content;
   final WishlistStatus status;
   @JsonKey(name: 'release_date')
-  final String releaseDate;
+  final String? releaseDate;
   @JsonKey(name: 'prototype_url')
-  final String prototypeUrl;
+  final String? prototypeUrl;
   @JsonKey(name: 'rating')
   final RatingModel ratingModel;
   @JsonKey(name: 'images')
   final List<ImageModel> imageModels;
-  @JsonKey(name: 'created_at')
-  final String createdAt;
-  @JsonKey(name: 'updated_at')
+  @JsonKey(name: 'date_updated')
   final String updatedAt;
 
   const WishlistModel({
     required this.id,
     required this.title,
     required this.description,
-    required this.descriptionShort,
+    required this.content,
     required this.status,
-    required this.releaseDate,
-    required this.prototypeUrl,
+    this.releaseDate,
+    this.prototypeUrl,
     required this.ratingModel,
     required this.imageModels,
-    required this.createdAt,
     required this.updatedAt,
   });
 
@@ -50,13 +46,12 @@ class WishlistModel extends RWishlistModel {
         id,
         title,
         description,
-        descriptionShort,
+        content,
         status,
         releaseDate,
         prototypeUrl,
         ratingModel,
         imageModels,
-        createdAt,
         updatedAt,
       ];
 }

--- a/feature_modules/wishlist/lib/src/repository/api/models/wishlist_model.g.dart
+++ b/feature_modules/wishlist/lib/src/repository/api/models/wishlist_model.g.dart
@@ -7,32 +7,30 @@ part of 'wishlist_model.dart';
 // **************************************************************************
 
 WishlistModel _$WishlistModelFromJson(Map<String, dynamic> json) => WishlistModel(
-      id: (json['id'] as num).toInt(),
+      id: json['id'] as String,
       title: json['title'] as String,
       description: json['description'] as String,
-      descriptionShort: json['description_short'] as String,
+      content: json['content'] as String,
       status: $enumDecode(_$WishlistStatusEnumMap, json['status']),
-      releaseDate: json['release_date'] as String,
-      prototypeUrl: json['prototype_url'] as String,
+      releaseDate: json['release_date'] as String?,
+      prototypeUrl: json['prototype_url'] as String?,
       ratingModel: RatingModel.fromJson(json['rating'] as Map<String, dynamic>),
       imageModels:
           (json['images'] as List<dynamic>).map((e) => ImageModel.fromJson(e as Map<String, dynamic>)).toList(),
-      createdAt: json['created_at'] as String,
-      updatedAt: json['updated_at'] as String,
+      updatedAt: json['date_updated'] as String,
     );
 
 Map<String, dynamic> _$WishlistModelToJson(WishlistModel instance) => <String, dynamic>{
       'id': instance.id,
       'title': instance.title,
       'description': instance.description,
-      'description_short': instance.descriptionShort,
+      'content': instance.content,
       'status': _$WishlistStatusEnumMap[instance.status]!,
       'release_date': instance.releaseDate,
       'prototype_url': instance.prototypeUrl,
       'rating': instance.ratingModel,
       'images': instance.imageModels,
-      'created_at': instance.createdAt,
-      'updated_at': instance.updatedAt,
+      'date_updated': instance.updatedAt,
     };
 
 const _$WishlistStatusEnumMap = {

--- a/feature_modules/wishlist/lib/src/repository/api/wishlist_api_client.dart
+++ b/feature_modules/wishlist/lib/src/repository/api/wishlist_api_client.dart
@@ -9,8 +9,8 @@ import 'wishlist_api_endpoints.dart';
 class WishlistApiClient {
   final _baseApiClient = GetIt.I.get<BaseApiClient>();
 
-  Future<List<WishlistModel>> getWishlistModels({int? id}) async {
-    final response = await _baseApiClient.get(WishlistApiEndpoints.getWishlistModels(id: id));
+  Future<List<WishlistModel>> getWishlistModels({String? id}) async {
+    final response = await _baseApiClient.get(WishlistApiEndpoints.getWishlistModels(id: id), version: 2);
 
     if (response.statusCode == 200) {
       final jsonList = json.decode(response.body) as List<dynamic>;
@@ -22,8 +22,8 @@ class WishlistApiClient {
     }
   }
 
-  Future<bool> toggleWishlistLike({required int id}) async {
-    final response = await _baseApiClient.post(WishlistApiEndpoints.toggleWishlistLike(id));
+  Future<bool> toggleWishlistLike({required String id}) async {
+    final response = await _baseApiClient.post(WishlistApiEndpoints.toggleWishlistLike(id), version: 2);
 
     if (response.statusCode == 200) {
       return response.body == 'true';

--- a/feature_modules/wishlist/lib/src/repository/api/wishlist_api_endpoints.dart
+++ b/feature_modules/wishlist/lib/src/repository/api/wishlist_api_endpoints.dart
@@ -3,12 +3,12 @@ class WishlistApiEndpoints {
 
   static const String _toggleLike = '/toggle-like';
 
-  static String getWishlistModels({int? id}) {
+  static String getWishlistModels({String? id}) {
     final query = id == null ? '' : '?id=$id';
     return '$_wishlistRoute$query';
   }
 
-  static String toggleWishlistLike(int id) {
+  static String toggleWishlistLike(String id) {
     return '$_wishlistRoute$_toggleLike?id=$id';
   }
 }

--- a/feature_modules/wishlist/lib/src/repository/wishlist_repository.dart
+++ b/feature_modules/wishlist/lib/src/repository/wishlist_repository.dart
@@ -6,13 +6,13 @@ import 'api/models/wishlist_model.dart';
 import 'api/wishlist_api_client.dart';
 
 abstract class WishlistRepository {
-  Future<List<WishlistModel>?> getWishlistEntries({int? id});
+  Future<List<WishlistModel>?> getWishlistEntries();
 
-  Future<List<WishlistModel>?> getCachedWishlistEntries({int? id});
+  Future<List<WishlistModel>?> getCachedWishlistEntries({String? id});
 
   Future<List<String>?> getLikedWishlistIds();
 
-  Future<bool> toggleWishlistLike(int id);
+  Future<bool> toggleWishlistLike(String id);
 
   Future<void> saveLikedWishlistIds(List<String> ids);
 
@@ -34,10 +34,10 @@ class ConnectedWishlistRepository implements WishlistRepository {
   static const String _likedWishlistIdsKey = 'liked_wishlist_ids_key';
 
   @override
-  Future<List<WishlistModel>?> getWishlistEntries({int? id}) async {
+  Future<List<WishlistModel>?> getWishlistEntries() async {
     final prefs = await SharedPreferences.getInstance();
     try {
-      final wishlistEntries = await wishlistApiClient.getWishlistModels(id: id);
+      final wishlistEntries = await wishlistApiClient.getWishlistModels(id: null);
       await prefs.setString(_cachedWishlistEntriesKey, jsonEncode(wishlistEntries.map((e) => e.toJson()).toList()));
       await prefs.setInt(_cachedWihshlistEntriesTimestampKey, DateTime.now().millisecondsSinceEpoch);
       return wishlistEntries;
@@ -47,7 +47,7 @@ class ConnectedWishlistRepository implements WishlistRepository {
   }
 
   @override
-  Future<List<WishlistModel>?> getCachedWishlistEntries({int? id}) async {
+  Future<List<WishlistModel>?> getCachedWishlistEntries({String? id}) async {
     final prefs = await SharedPreferences.getInstance();
     final cachedData = prefs.getString(_cachedWishlistEntriesKey);
     final cachedTimeStamp = prefs.getInt(_cachedWihshlistEntriesTimestampKey);
@@ -59,6 +59,7 @@ class ConnectedWishlistRepository implements WishlistRepository {
         final List<dynamic> jsonList = jsonDecode(cachedData);
         return jsonList.map((e) => WishlistModel.fromJson(e as Map<String, dynamic>)).toList();
       } catch (e) {
+        prefs.remove(_cachedWishlistEntriesKey);
         return null;
       }
     }
@@ -74,7 +75,7 @@ class ConnectedWishlistRepository implements WishlistRepository {
   }
 
   @override
-  Future<bool> toggleWishlistLike(int id) async {
+  Future<bool> toggleWishlistLike(String id) async {
     return await wishlistApiClient.toggleWishlistLike(id: id);
   }
 

--- a/feature_modules/wishlist/lib/src/services/wishlist_user_preference_service.dart
+++ b/feature_modules/wishlist/lib/src/services/wishlist_user_preference_service.dart
@@ -55,7 +55,7 @@ class WishlistUserPreferenceService {
 
         final missingSyncWishlistIds = unsyncedLikedWishlistIds + unsyncedUnlikedWishlistIds;
         for (final missingSyncWishlistId in missingSyncWishlistIds) {
-          await _wishlistRepository.toggleWishlistLike(int.parse(missingSyncWishlistId));
+          await _wishlistRepository.toggleWishlistLike(missingSyncWishlistId);
         }
       }
     });
@@ -73,6 +73,6 @@ class WishlistUserPreferenceService {
     _likedWishlistIdsNotifier.value = likedWishlistIds;
     await _wishlistRepository.saveLikedWishlistIds(likedWishlistIds);
 
-    await _wishlistRepository.toggleWishlistLike(int.parse(id));
+    await _wishlistRepository.toggleWishlistLike(id);
   }
 }

--- a/feature_modules/wishlist/lib/src/widgets/wishlist_entry_section.dart
+++ b/feature_modules/wishlist/lib/src/widgets/wishlist_entry_section.dart
@@ -55,7 +55,7 @@ class WishlistEntrySection extends StatelessWidget {
                       titleInTextVisuals: wishlistModel.status.getValue(context).isNotEmpty
                           ? [LmuInTextVisual.text(title: wishlistModel.status.getValue(context))]
                           : [],
-                      subtitle: wishlistModel.descriptionShort,
+                      subtitle: wishlistModel.description,
                       trailingTitle: wishlistModel.ratingModel.calculateLikeCount(
                         likedWishlistIds.contains(wishlistModel.id.toString()),
                       ),


### PR DESCRIPTION
Use new v2 endpoint for wishlist request (content and likes).
Adjust DTO models, description_short -> description, description -> content.