### PR TITLE
379 Activate Filters on Map Button

### DIFF
--- a/core/lib/src/components/buttons/lmu_button_row.dart
+++ b/core/lib/src/components/buttons/lmu_button_row.dart
@@ -5,15 +5,18 @@ class LmuButtonRow extends StatelessWidget {
   const LmuButtonRow({
     super.key,
     required this.buttons,
+    this.controller,
     this.hasHorizontalPadding = true,
   });
 
   final List<Widget> buttons;
+  final ScrollController? controller;
   final bool hasHorizontalPadding;
 
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
+      controller: controller,
       scrollDirection: Axis.horizontal,
       child: Padding(
         padding: EdgeInsets.symmetric(

--- a/core_routes/lib/src/config/shell_route_data.g.dart
+++ b/core_routes/lib/src/config/shell_route_data.g.dart
@@ -764,11 +764,16 @@ extension $MensaSearchRouteExtension on MensaSearchRoute {
 }
 
 extension $ExploreMainRouteExtension on ExploreMainRoute {
-  static ExploreMainRoute _fromState(GoRouterState state) => const ExploreMainRoute();
+  static ExploreMainRoute _fromState(GoRouterState state) => ExploreMainRoute(
+    filter: state.uri.queryParameters['filter'],
+  );
 
   String get location => GoRouteData.$location(
-        '/explore',
-      );
+    '/explore',
+    queryParams: {
+      if (filter != null) 'filter': filter,
+    },
+  );
 
   void go(BuildContext context) => context.go(location);
 

--- a/core_routes/lib/src/explore/router/explore_router.dart
+++ b/core_routes/lib/src/explore/router/explore_router.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 abstract class ExploreRouter {
-  Widget buildMain(BuildContext context);
+  Widget buildMain(BuildContext context, {String? filter});
 
   Widget buildSearch(BuildContext context);
 }

--- a/core_routes/lib/src/explore/routes/explore_routes.dart
+++ b/core_routes/lib/src/explore/routes/explore_routes.dart
@@ -11,12 +11,14 @@ class ExploreData extends StatefulShellBranchData {
 }
 
 class ExploreMainRoute extends GoRouteData {
-  const ExploreMainRoute();
+  const ExploreMainRoute({this.filter});
 
+  final String? filter;
   static const String path = '/explore';
 
   @override
-  Widget build(BuildContext context, GoRouterState state) => _router.buildMain(context);
+  Widget build(BuildContext context, GoRouterState state) =>
+      _router.buildMain(context, filter: filter);
 }
 
 class ExploreSearchRoute extends GoRouteData {
@@ -25,5 +27,6 @@ class ExploreSearchRoute extends GoRouteData {
   static const String path = 'search';
 
   @override
-  Widget build(BuildContext context, GoRouterState state) => _router.buildSearch(context);
+  Widget build(BuildContext context, GoRouterState state) =>
+      _router.buildSearch(context);
 }

--- a/feature_modules/explore/lib/src/pages/explore_page.dart
+++ b/feature_modules/explore/lib/src/pages/explore_page.dart
@@ -72,8 +72,18 @@ class ExplorePage extends DrivableWidget<ExplorePageDriver> {
                 tileProvider: driver.tileProvider,
               ),
               const CurrentLocationLayer(),
-              MarkerLayer(rotate: true, markers: driver.locations.map((location) => location.toMarker).toList()),
-              Positioned(bottom: 0, width: screenWidth, child: const ExploreMapOverlay()),
+              MarkerLayer(
+                  rotate: true,
+                  markers: driver.locations
+                      .map((location) => location.toMarker)
+                      .toList()),
+              Positioned(
+                bottom: 0,
+                width: screenWidth,
+                child: ExploreMapOverlay(
+                  filterScrollController: driver.filterScrollController,
+                ),
+              ),
             ],
           ),
           const ExploreMapContentSheet(),

--- a/feature_modules/explore/lib/src/pages/explore_page_driver.g.dart
+++ b/feature_modules/explore/lib/src/pages/explore_page_driver.g.dart
@@ -8,9 +8,12 @@ part of 'explore_page_driver.dart';
 
 // coverage:ignore-file
 
-// This file was generated with widget_driver_generator version "1.3.3"
+// This file was generated with widget_driver_generator version "1.3.5"
 
 class _$TestExplorePageDriver extends TestDriver implements ExplorePageDriver {
+  @override
+  ScrollController filterScrollController = const _TestScrollController();
+
   @override
   MapController get mapController => const _TestMapController();
 

--- a/feature_modules/explore/lib/src/routes/explore_router.dart
+++ b/feature_modules/explore/lib/src/routes/explore_router.dart
@@ -1,12 +1,28 @@
 import 'package:core_routes/explore.dart';
 import 'package:flutter/widgets.dart';
+import 'package:get_it/get_it.dart';
 
 import '../pages/explore_page.dart';
 import '../pages/explore_search_page.dart';
+import '../services/explore_location_service.dart';
 
 class ExploreRouterImpl extends ExploreRouter {
   @override
-  Widget buildMain(BuildContext context) => const ExploreMapAnimationWrapper();
+  Widget buildMain(BuildContext context, {String? filter}) {
+    if (filter != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        try {
+          final locationService = GetIt.I<ExploreLocationService>();
+          final filterType = ExploreFilterType.values.byName(filter);
+          locationService.applyInitialFilter(filterType);
+        } catch (e) {
+          throw Exception("Filter [$filter] could not be applied: $e");
+        }
+      });
+    }
+
+    return const ExploreMapAnimationWrapper();
+  }
 
   @override
   Widget buildSearch(BuildContext context) => const ExploreSearchPage();

--- a/feature_modules/explore/lib/src/routes/explore_router.dart
+++ b/feature_modules/explore/lib/src/routes/explore_router.dart
@@ -1,6 +1,7 @@
 import 'package:core_routes/explore.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_api/explore.dart';
 
 import '../pages/explore_page.dart';
 import '../pages/explore_search_page.dart';

--- a/feature_modules/explore/lib/src/services/explore_location_service.dart
+++ b/feature_modules/explore/lib/src/services/explore_location_service.dart
@@ -37,6 +37,11 @@ class ExploreLocationService {
     }
   }
 
+  void applyInitialFilter(ExploreFilterType type) {
+    _filterNotifier.value = [type];
+    _updateFilteredExploreLocations();
+  }
+
   void updateFilter(ExploreFilterType type) {
     final currentFilters = List.of(_filterNotifier.value);
     if (currentFilters.contains(type)) {

--- a/feature_modules/explore/lib/src/services/explore_location_service.dart
+++ b/feature_modules/explore/lib/src/services/explore_location_service.dart
@@ -6,8 +6,6 @@ import 'package:shared_api/libraries.dart';
 import 'package:shared_api/mensa.dart';
 import 'package:shared_api/roomfinder.dart';
 
-enum ExploreFilterType { mensa, building, library, cinema }
-
 class ExploreLocationService {
   final ValueNotifier<List<ExploreLocation>> _locationsNotifier = ValueNotifier([]);
   final ValueNotifier<List<ExploreLocation>> _filteredLocationsNotifier = ValueNotifier([]);

--- a/feature_modules/explore/lib/src/widgets/explore_action_row.dart
+++ b/feature_modules/explore/lib/src/widgets/explore_action_row.dart
@@ -15,7 +15,9 @@ import '../services/explore_map_service.dart';
 import 'explore_map_dot.dart';
 
 class ExploreActionRow extends StatelessWidget {
-  const ExploreActionRow({super.key});
+  const ExploreActionRow({super.key, required this.filterScrollController});
+
+  final ScrollController filterScrollController;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +38,7 @@ class ExploreActionRow extends StatelessWidget {
         valueListenable: locationService.filterNotifier,
         builder: (context, activeFilters, child) {
           return LmuButtonRow(
+            controller: filterScrollController,
             buttons: [
               LmuButton(
                 title: context.locals.app.search,

--- a/feature_modules/explore/lib/src/widgets/explore_map_overlay.dart
+++ b/feature_modules/explore/lib/src/widgets/explore_map_overlay.dart
@@ -8,7 +8,9 @@ import 'explore_action_row.dart';
 import 'explore_location_button.dart';
 
 class ExploreMapOverlay extends StatelessWidget {
-  const ExploreMapOverlay({super.key});
+  const ExploreMapOverlay({super.key, required this.filterScrollController});
+
+  final ScrollController filterScrollController;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +35,7 @@ class ExploreMapOverlay extends StatelessWidget {
             ],
           ),
         ),
-        const ExploreActionRow(),
+        ExploreActionRow(filterScrollController: filterScrollController),
       ],
     );
   }

--- a/feature_modules/libraries/lib/src/widgets/libraries_overview_button_section.dart
+++ b/feature_modules/libraries/lib/src/widgets/libraries_overview_button_section.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_api/explore.dart';
 
 import '../repository/api/api.dart';
 import '../repository/api/enums/sort_options.dart';
@@ -29,7 +30,7 @@ class LibrariesOverviewButtonSection extends StatelessWidget {
       scrollDirection: Axis.horizontal,
       child: LmuButtonRow(
         buttons: [
-          LmuMapImageButton(onTap: () => const ExploreMainRoute(filter: 'library').go(context)),
+          LmuMapImageButton(onTap: () => ExploreMainRoute(filter: ExploreFilterType.library.name).go(context)),
           LmuIconButton(
             icon: LucideIcons.search,
             onPressed: () => const LibrariesSearchRoute().go(context),

--- a/feature_modules/libraries/lib/src/widgets/libraries_overview_button_section.dart
+++ b/feature_modules/libraries/lib/src/widgets/libraries_overview_button_section.dart
@@ -29,7 +29,7 @@ class LibrariesOverviewButtonSection extends StatelessWidget {
       scrollDirection: Axis.horizontal,
       child: LmuButtonRow(
         buttons: [
-          LmuMapImageButton(onTap: () => const ExploreMainRoute().go(context)),
+          LmuMapImageButton(onTap: () => const ExploreMainRoute(filter: 'library').go(context)),
           LmuIconButton(
             icon: LucideIcons.search,
             onPressed: () => const LibrariesSearchRoute().go(context),

--- a/feature_modules/mensa/lib/src/widgets/overview/mensa_overview_button_section.dart
+++ b/feature_modules/mensa/lib/src/widgets/overview/mensa_overview_button_section.dart
@@ -27,7 +27,7 @@ class MensaOverviewButtonSection extends StatelessWidget {
 
     return LmuButtonRow(
       buttons: [
-        LmuMapImageButton(onTap: () => const ExploreMainRoute().go(context)),
+        LmuMapImageButton(onTap: () => const ExploreMainRoute(filter: 'mensa').go(context)),
         LmuIconButton(
           icon: LucideIcons.search,
           onPressed: () => const MensaSearchRoute().go(context),

--- a/feature_modules/mensa/lib/src/widgets/overview/mensa_overview_button_section.dart
+++ b/feature_modules/mensa/lib/src/widgets/overview/mensa_overview_button_section.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_api/explore.dart';
 
 import '../../repository/api/models/mensa/mensa_model.dart';
 import '../../repository/api/models/user_preferences/sort_option.dart';
@@ -27,7 +28,7 @@ class MensaOverviewButtonSection extends StatelessWidget {
 
     return LmuButtonRow(
       buttons: [
-        LmuMapImageButton(onTap: () => const ExploreMainRoute(filter: 'mensa').go(context)),
+        LmuMapImageButton(onTap: () => ExploreMainRoute(filter: ExploreFilterType.mensa.name).go(context)),
         LmuIconButton(
           icon: LucideIcons.search,
           onPressed: () => const MensaSearchRoute().go(context),

--- a/feature_modules/roomfinder/lib/src/widgets/roomfinder_button_section.dart
+++ b/feature_modules/roomfinder/lib/src/widgets/roomfinder_button_section.dart
@@ -37,7 +37,7 @@ class _RoomfinderButtonSectionState extends State<RoomfinderButtonSection> {
         LmuTileHeadline.base(title: context.locals.roomfinder.allBuildings),
         Row(
           children: [
-            LmuMapImageButton(onTap: () => const ExploreMainRoute().go(context)),
+            LmuMapImageButton(onTap: () => const ExploreMainRoute(filter: 'building').go(context)),
             const SizedBox(width: LmuSizes.size_8),
             LmuIconButton(
               icon: LucideIcons.search,

--- a/feature_modules/roomfinder/lib/src/widgets/roomfinder_button_section.dart
+++ b/feature_modules/roomfinder/lib/src/widgets/roomfinder_button_section.dart
@@ -8,6 +8,7 @@ import 'package:core_routes/roomfinder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_api/explore.dart';
 
 import '../repository/api/enums/roomfinder_sort_option.dart';
 import '../services/roomfinder_filter_service.dart';
@@ -37,7 +38,7 @@ class _RoomfinderButtonSectionState extends State<RoomfinderButtonSection> {
         LmuTileHeadline.base(title: context.locals.roomfinder.allBuildings),
         Row(
           children: [
-            LmuMapImageButton(onTap: () => const ExploreMainRoute(filter: 'building').go(context)),
+            LmuMapImageButton(onTap: () => ExploreMainRoute(filter: ExploreFilterType.building.name).go(context)),
             const SizedBox(width: LmuSizes.size_8),
             LmuIconButton(
               icon: LucideIcons.search,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -88,22 +88,22 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
-  flutter_rotation_sensor: bf55ead3f64f27207dacc5972fe8ebe932f3de0b
-  fluttertoast: 2c67e14dce98bbdb200df9e1acf610d7a6264ea1
-  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
-  in_app_review: 5596fe56fab799e8edb3561c03d053363ab13457
-  native_device_orientation: e3580675687d5034770da198f6839ebf2122ef94
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  flutter_native_splash: f71420956eb811e6d310720fee915f1d42852e7a
+  flutter_rotation_sensor: f37d8d24050572029bdd2d55a93e0f334e2eeac6
+  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
+  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  in_app_review: a31b5257259646ea78e0e35fc914979b0031d011
+  native_device_orientation: 348b10c346a60ebbc62fb235a4fdb5d1b61a8f55
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: f30ac5f16bf3f5728d744b349df342ed78751a0b
 

--- a/shared_api/lib/src/explore/models/explore_filter_type.dart
+++ b/shared_api/lib/src/explore/models/explore_filter_type.dart
@@ -1,0 +1,6 @@
+enum ExploreFilterType {
+  mensa,
+  building,
+  library,
+  cinema,
+}

--- a/shared_api/lib/src/explore/models/models.dart
+++ b/shared_api/lib/src/explore/models/models.dart
@@ -1,2 +1,3 @@
 export 'explore_location.dart';
 export 'explore_marker_type.dart';
+export 'explore_filter_type.dart';


### PR DESCRIPTION
## 🔗 Related Issue(s)

<!-- Link to any relevant GitHub issues. Use keywords like "Closes #123" or "Fixes #456". -->
- Closes #379 
- Addresses #379 

---

## 🛠️ Type of Change

<!-- Please check the boxes that apply. -->
- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation update
- [ ] 💅 Style
- [x] ♻️ Refactor

---

## 📝 Description

<!--
Provide a clear and concise summary of the changes.
What problem does it solve or what feature does it add?
Why is this change necessary?
-->
The map buttons on overview pages of canteens, libraries and the buildings do now not only navigate to the map screen but also activate the corresponding filters.

---
