### PR TITLE
feat(401): implement basic faculty selection

### DIFF
--- a/core_routes/lib/src/config/shell_route_data.dart
+++ b/core_routes/lib/src/config/shell_route_data.dart
@@ -16,6 +16,7 @@ import '../mensa/mensa.dart';
 import '../roomfinder/roomfinder.dart';
 import '../settings/settings.dart';
 import '../sports/sports.dart';
+import '../studies/studies.dart';
 import '../timeline/timeline.dart';
 import '../wishlist/wishlist.dart';
 import 'scaffold_with_nav_bar.dart';
@@ -63,6 +64,9 @@ class LaunchFlowShellRoute extends ShellRouteData {
                 ),
                 TypedGoRoute<SettingsDebugRoute>(
                   path: SettingsDebugRoute.path,
+                ),
+                TypedGoRoute<FaculitesMainRoute>(
+                  path: FaculitesMainRoute.path,
                 ),
               ],
             ),

--- a/core_routes/lib/src/config/shell_route_data.g.dart
+++ b/core_routes/lib/src/config/shell_route_data.g.dart
@@ -96,6 +96,10 @@ RouteBase get $mainShellRouteData => StatefulShellRouteData.$route(
                       path: 'debug',
                       factory: $SettingsDebugRouteExtension._fromState,
                     ),
+                    GoRouteData.$route(
+                      path: 'faculites',
+                      factory: $FaculitesMainRouteExtension._fromState,
+                    ),
                   ],
                 ),
                 GoRouteData.$route(
@@ -370,6 +374,22 @@ extension $SettingsDebugRouteExtension on SettingsDebugRoute {
 
   String get location => GoRouteData.$location(
         '/home/settings/debug',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $FaculitesMainRouteExtension on FaculitesMainRoute {
+  static FaculitesMainRoute _fromState(GoRouterState state) => const FaculitesMainRoute();
+
+  String get location => GoRouteData.$location(
+        '/home/settings/faculites',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -776,19 +796,17 @@ extension $MensaSearchRouteExtension on MensaSearchRoute {
 }
 
 extension $ExploreMainRouteExtension on ExploreMainRoute {
-  static ExploreMainRoute _fromState(GoRouterState state) =>
-      const ExploreMainRoute();
+  static ExploreMainRoute _fromState(GoRouterState state) => const ExploreMainRoute();
 
   String get location => GoRouteData.$location(
-    '/explore',
-  );
+        '/explore',
+      );
 
   void go(BuildContext context) => context.go(location);
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
+  void pushReplacement(BuildContext context) => context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }

--- a/core_routes/lib/src/studies/router/studies_router.dart
+++ b/core_routes/lib/src/studies/router/studies_router.dart
@@ -2,4 +2,6 @@ import 'package:flutter/widgets.dart';
 
 abstract class StudiesRouter {
   Widget buildMain(BuildContext context);
+
+  Widget buildFaculites(BuildContext context);
 }

--- a/core_routes/lib/src/studies/routes/studies_routes.dart
+++ b/core_routes/lib/src/studies/routes/studies_routes.dart
@@ -18,3 +18,12 @@ class StudiesMainRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) => _router.buildMain(context);
 }
+
+class FaculitesMainRoute extends GoRouteData {
+  const FaculitesMainRoute();
+
+  static const String path = 'faculites';
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => _router.buildFaculites(context);
+}

--- a/core_routes/lib/studies.dart
+++ b/core_routes/lib/studies.dart
@@ -1,4 +1,4 @@
 library core_routes.studies;
 
-export 'src/config/shell_route_data.dart' show $StudiesMainRouteExtension;
+export 'src/config/shell_route_data.dart' show $StudiesMainRouteExtension, $FaculitesMainRouteExtension;
 export 'src/studies/studies.dart';

--- a/feature_modules/settings/lib/src/pages/settings_page.dart
+++ b/feature_modules/settings/lib/src/pages/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:core/localizations.dart';
 import 'package:core/themes.dart';
 import 'package:core/utils.dart';
 import 'package:core_routes/settings.dart';
+import 'package:core_routes/studies.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
@@ -44,11 +45,18 @@ class SettingsMainPage extends StatelessWidget {
             children: [
               const SizedBox(height: LmuSizes.size_16),
               LmuContentTile(
-                content: LmuListItem.action(
-                  title: settingLocalizations.account,
-                  actionType: LmuListItemAction.chevron,
-                  onTap: () => const SettingsAccountRoute().go(context),
-                ),
+                contentList: [
+                  LmuListItem.action(
+                    title: settingLocalizations.account,
+                    actionType: LmuListItemAction.chevron,
+                    onTap: () => const SettingsAccountRoute().go(context),
+                  ),
+                  LmuListItem.action(
+                    title: settingLocalizations.changeFaculty,
+                    actionType: LmuListItemAction.chevron,
+                    onTap: () => const FaculitesMainRoute().go(context),
+                  ),
+                ],
               ),
               const SizedBox(height: LmuSizes.size_16),
               LmuContentTile(

--- a/feature_modules/studies/lib/src/application/usecase/get_faculties_usecase.dart
+++ b/feature_modules/studies/lib/src/application/usecase/get_faculties_usecase.dart
@@ -1,0 +1,41 @@
+import 'package:core/logging.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_api/studies.dart';
+
+import '../../domain/exception/studies_generic_exception.dart';
+import '../../domain/interface/studies_repository_interface.dart';
+
+class GetFacultiesUsecase extends ChangeNotifier {
+  GetFacultiesUsecase(this._repository);
+
+  final StudiesRepositoryInterface _repository;
+
+  List<Faculty> _faculties = [];
+  List<Faculty> _selectedFaculties = [];
+
+  List<Faculty> get allFaculites => _faculties;
+  List<Faculty> get selectedFaculties => _selectedFaculties;
+
+  void selectFaculites(List<Faculty> faculites) {
+    _selectedFaculties = faculites;
+    _repository.saveSelectedFacultyIds(faculites.map((f) => f.id).toList());
+  }
+
+  Future<void> initFaculites() async {
+    try {
+      final faculties = await _repository.getFaculties(forceRefresh: true);
+      _faculties = faculties;
+
+      final selectedFaculties = await _repository.getSelectedFacultyIds();
+      _selectedFaculties = _faculties.where((faculty) => selectedFaculties.contains(faculty.id)).toList();
+
+      notifyListeners();
+    } on StudiesGenericException {
+      //TODO: Error handling if api request fails and nothing cached yet
+    }
+
+    AppLogger().logMessage(
+      "[GetFacultiesUsecase]: initialized with ${_faculties.length} faculties and selected faculties ${_selectedFaculties.map((f) => f.id)}.",
+    );
+  }
+}

--- a/feature_modules/studies/lib/src/application/usecase/get_faculties_usecase.dart
+++ b/feature_modules/studies/lib/src/application/usecase/get_faculties_usecase.dart
@@ -23,7 +23,7 @@ class GetFacultiesUsecase extends ChangeNotifier {
 
   Future<void> initFaculites() async {
     try {
-      final faculties = await _repository.getFaculties(forceRefresh: true);
+      final faculties = await _repository.getFaculties();
       _faculties = faculties;
 
       final selectedFaculties = await _repository.getSelectedFacultyIds();

--- a/feature_modules/studies/lib/src/domain/exception/studies_generic_exception.dart
+++ b/feature_modules/studies/lib/src/domain/exception/studies_generic_exception.dart
@@ -1,0 +1,8 @@
+class StudiesGenericException implements Exception {
+  const StudiesGenericException([this.message = 'An unexpected error occurred.']);
+
+  final String message;
+
+  @override
+  String toString() => 'Exception: $message';
+}

--- a/feature_modules/studies/lib/src/domain/interface/studies_repository_interface.dart
+++ b/feature_modules/studies/lib/src/domain/interface/studies_repository_interface.dart
@@ -1,0 +1,11 @@
+import 'package:shared_api/studies.dart';
+
+abstract class StudiesRepositoryInterface {
+  Future<List<Faculty>> getFaculties({bool forceRefresh = false});
+
+  Future<void> saveSelectedFacultyIds(List<int> faculties);
+
+  Future<List<int>> getSelectedFacultyIds();
+
+  Future<void> clearSelectedFacultyIds();
+}

--- a/feature_modules/studies/lib/src/domain/model/faculty.dart
+++ b/feature_modules/studies/lib/src/domain/model/faculty.dart
@@ -1,0 +1,11 @@
+import 'package:shared_api/studies.dart';
+
+class FacultyImpl implements Faculty {
+  const FacultyImpl({required this.id, required this.name});
+
+  @override
+  final int id;
+
+  @override
+  final String name;
+}

--- a/feature_modules/studies/lib/src/infrastructure/primary/api/faculties_api.dart
+++ b/feature_modules/studies/lib/src/infrastructure/primary/api/faculties_api.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+import 'package:shared_api/studies.dart';
+
+import '../../../application/usecase/get_faculties_usecase.dart';
+
+class FacultiesApiImpl implements FacultiesApi {
+  FacultiesApiImpl(this._getFacultiesUsecase) {
+    _getFacultiesUsecase.addListener(_onChange);
+  }
+
+  final GetFacultiesUsecase _getFacultiesUsecase;
+  final StreamController<List<Faculty>> _selectedFacultiesController = StreamController<List<Faculty>>.broadcast();
+
+  @override
+  List<Faculty> get allFaculties => _getFacultiesUsecase.allFaculites;
+
+  @override
+  List<Faculty> get selectedFaculties => _getFacultiesUsecase.selectedFaculties;
+
+  @override
+  Stream<List<Faculty>> get selectedFacultiesStream => _selectedFacultiesController.stream;
+
+  void _onChange() {
+    _selectedFacultiesController.add(_getFacultiesUsecase.selectedFaculties);
+  }
+
+  void dispose() {
+    _getFacultiesUsecase.removeListener(_onChange);
+    _selectedFacultiesController.close();
+  }
+}

--- a/feature_modules/studies/lib/src/infrastructure/primary/router/studies_router.dart
+++ b/feature_modules/studies/lib/src/infrastructure/primary/router/studies_router.dart
@@ -1,9 +1,13 @@
 import 'package:core_routes/studies.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../presentation/view/faculites_page.dart';
 import '../../../presentation/view/studies_page.dart';
 
 class StudiesRouterImpl extends StudiesRouter {
   @override
   Widget buildMain(BuildContext context) => StudiesPage();
+
+  @override
+  Widget buildFaculites(BuildContext context) => FaculitesPage();
 }

--- a/feature_modules/studies/lib/src/infrastructure/secondary/data/api/studies_api_client.dart
+++ b/feature_modules/studies/lib/src/infrastructure/secondary/data/api/studies_api_client.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:core/api.dart';
+
+import '../dto/faculty_dto.dart';
+import 'studies_api_endpoints.dart';
+
+class StudiesApiClient {
+  const StudiesApiClient(this._baseApiClient);
+
+  final BaseApiClient _baseApiClient;
+
+  Future<List<FacultyDto>> getFaculties() async {
+    final response = await _baseApiClient.get(StudiesApiEndpoints.faculties);
+
+    final List<dynamic> data = json.decode(response.body);
+    return data.map((json) => FacultyDto.fromJson(json)).toList();
+  }
+}

--- a/feature_modules/studies/lib/src/infrastructure/secondary/data/api/studies_api_endpoints.dart
+++ b/feature_modules/studies/lib/src/infrastructure/secondary/data/api/studies_api_endpoints.dart
@@ -1,0 +1,3 @@
+class StudiesApiEndpoints {
+  static const faculties = '/faculties';
+}

--- a/feature_modules/studies/lib/src/infrastructure/secondary/data/dto/faculty_dto.dart
+++ b/feature_modules/studies/lib/src/infrastructure/secondary/data/dto/faculty_dto.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../../../domain/model/faculty.dart';
+
+part 'faculty_dto.g.dart';
+
+@JsonSerializable()
+class FacultyDto extends Equatable {
+  const FacultyDto({
+    required this.id,
+    required this.name,
+  });
+
+  factory FacultyDto.fromJson(Map<String, dynamic> json) => _$FacultyDtoFromJson(json);
+
+  final int id;
+  final String name;
+
+  FacultyImpl toDomain() => FacultyImpl(
+        id: id,
+        name: name,
+      );
+
+  Map<String, dynamic> toJson() => _$FacultyDtoToJson(this);
+
+  @override
+  List<Object?> get props => [id, name];
+}

--- a/feature_modules/studies/lib/src/infrastructure/secondary/data/dto/faculty_dto.g.dart
+++ b/feature_modules/studies/lib/src/infrastructure/secondary/data/dto/faculty_dto.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'faculty_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FacultyDto _$FacultyDtoFromJson(Map<String, dynamic> json) => FacultyDto(
+      id: (json['id'] as num).toInt(),
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$FacultyDtoToJson(FacultyDto instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };

--- a/feature_modules/studies/lib/src/infrastructure/secondary/data/storage/studies_storage.dart
+++ b/feature_modules/studies/lib/src/infrastructure/secondary/data/storage/studies_storage.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../dto/faculty_dto.dart';
+
+class StudiesStorage {
+  final _facultiesKey = 'faculties';
+  final _selectedFacultiesKey = 'selectedFaculties';
+
+  Future<void> saveFaculites(List<FacultyDto> faculties) async {
+    final prefs = await SharedPreferences.getInstance();
+    final facultyStrings = faculties.map((f) => jsonEncode(f.toJson())).toList();
+    await prefs.setStringList(_facultiesKey, facultyStrings);
+  }
+
+  Future<List<FacultyDto>> getFaculties() async {
+    final prefs = await SharedPreferences.getInstance();
+    final facultyStrings = prefs.getStringList(_facultiesKey) ?? [];
+    return facultyStrings.map((str) => FacultyDto.fromJson(jsonDecode(str))).toList();
+  }
+
+  Future<void> saveSelectedFaculties(List<int> facultyIds) async {
+    final prefs = await SharedPreferences.getInstance();
+    final idStrings = facultyIds.map((id) => id.toString()).toList();
+    await prefs.setStringList(_selectedFacultiesKey, idStrings);
+  }
+
+  Future<List<int>> getSelectedFaculties() async {
+    final prefs = await SharedPreferences.getInstance();
+    final idStrings = prefs.getStringList(_selectedFacultiesKey) ?? [];
+    return idStrings.map(int.parse).toList();
+  }
+
+  Future<void> clearSelectedFaculties() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_selectedFacultiesKey);
+  }
+}

--- a/feature_modules/studies/lib/src/infrastructure/secondary/repository/studies_repository.dart
+++ b/feature_modules/studies/lib/src/infrastructure/secondary/repository/studies_repository.dart
@@ -1,0 +1,44 @@
+import 'package:shared_api/studies.dart';
+
+import '../../../domain/exception/studies_generic_exception.dart';
+import '../../../domain/interface/studies_repository_interface.dart';
+import '../data/api/studies_api_client.dart';
+import '../data/storage/studies_storage.dart';
+
+class StudiesRepository implements StudiesRepositoryInterface {
+  const StudiesRepository(this._apiClient, this._storage);
+
+  final StudiesApiClient _apiClient;
+  final StudiesStorage _storage;
+
+  @override
+  Future<List<Faculty>> getFaculties({bool forceRefresh = false}) async {
+    try {
+      final cachedFaculties = await _storage.getFaculties();
+
+      if (cachedFaculties.isNotEmpty && !forceRefresh) {
+        return cachedFaculties.map((facultyDto) => facultyDto.toDomain()).toList();
+      }
+      final retrievedFacultiesData = await _apiClient.getFaculties();
+      await _storage.saveFaculites(retrievedFacultiesData);
+      return retrievedFacultiesData.map((facultyDto) => facultyDto.toDomain()).toList();
+    } catch (e) {
+      throw const StudiesGenericException();
+    }
+  }
+
+  @override
+  Future<List<int>> getSelectedFacultyIds() {
+    return _storage.getSelectedFaculties();
+  }
+
+  @override
+  Future<void> saveSelectedFacultyIds(List<int> faculties) {
+    return _storage.saveSelectedFaculties(faculties);
+  }
+
+  @override
+  Future<void> clearSelectedFacultyIds() {
+    return _storage.clearSelectedFaculties();
+  }
+}

--- a/feature_modules/studies/lib/src/presentation/view/faculites_page.dart
+++ b/feature_modules/studies/lib/src/presentation/view/faculites_page.dart
@@ -1,0 +1,45 @@
+import 'package:core/components.dart';
+import 'package:core/constants.dart';
+import 'package:flutter/widgets.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import '../viewmodel/faculites_page_driver.dart';
+
+class FaculitesPage extends DrivableWidget<FaculitesPageDriver> {
+  FaculitesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LmuScaffold(
+      appBar: LmuAppBarData(
+        leadingAction: LeadingAction.back,
+        largeTitle: driver.pageTitle,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: LmuSizes.size_16),
+        child: Column(
+          children: [
+            const SizedBox(height: LmuSizes.size_16),
+            LmuContentTile(
+              contentList: driver.allFaculties
+                  .map(
+                    (faculty) => LmuListItem.action(
+                      leadingArea: LmuText.h2(faculty.id.toString()),
+                      actionType: LmuListItemAction.checkbox,
+                      title: faculty.name,
+                      onChange: (val) => driver.onFacultySelected(faculty, val),
+                      initialValue: driver.selectedFaculties.contains(faculty),
+                    ),
+                  )
+                  .toList(),
+            ),
+            const SizedBox(height: LmuSizes.size_96),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  WidgetDriverProvider<FaculitesPageDriver> get driverProvider => $FaculitesPageDriverProvider();
+}

--- a/feature_modules/studies/lib/src/presentation/viewmodel/faculites_page_driver.dart
+++ b/feature_modules/studies/lib/src/presentation/viewmodel/faculites_page_driver.dart
@@ -1,0 +1,49 @@
+import 'package:core/localizations.dart';
+import 'package:get_it/get_it.dart';
+import 'package:shared_api/studies.dart';
+import 'package:widget_driver/widget_driver.dart';
+
+import '../../application/usecase/get_faculties_usecase.dart';
+
+part 'faculites_page_driver.g.dart';
+
+@GenerateTestDriver()
+class FaculitesPageDriver extends WidgetDriver {
+  late StudiesLocatizations _locatizations;
+  final _getFacultiesUseCase = GetIt.I.get<GetFacultiesUsecase>();
+
+  List<Faculty> _allFaculites = [];
+  List<Faculty> _selectedFaculites = [];
+
+  String get pageTitle => _locatizations.facultiesTitle;
+
+  List<Faculty> get allFaculties => _allFaculites;
+  List<Faculty> get selectedFaculties => _selectedFaculites;
+
+  void onFacultySelected(Faculty faculty, bool isSelected) {
+    if (isSelected) {
+      _selectedFaculites.add(faculty);
+    } else {
+      _selectedFaculites.removeWhere((f) => f.id == faculty.id);
+    }
+  }
+
+  @override
+  void didInitDriver() {
+    super.didInitDriver();
+    _allFaculites = _getFacultiesUseCase.allFaculites;
+    _selectedFaculites = _getFacultiesUseCase.selectedFaculties;
+  }
+
+  @override
+  void didUpdateBuildContext(BuildContext context) {
+    super.didUpdateBuildContext(context);
+    _locatizations = context.locals.studies;
+  }
+
+  @override
+  void dispose() {
+    _getFacultiesUseCase.selectFaculites(_selectedFaculites);
+    super.dispose();
+  }
+}

--- a/feature_modules/studies/lib/src/presentation/viewmodel/faculites_page_driver.g.dart
+++ b/feature_modules/studies/lib/src/presentation/viewmodel/faculites_page_driver.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'studies_page_driver.dart';
+part of 'faculites_page_driver.dart';
 
 // **************************************************************************
 // WidgetDriverGenerator
@@ -10,22 +10,28 @@ part of 'studies_page_driver.dart';
 
 // This file was generated with widget_driver_generator version "1.3.5"
 
-class _$TestStudiesPageDriver extends TestDriver implements StudiesPageDriver {
+class _$TestFaculitesPageDriver extends TestDriver implements FaculitesPageDriver {
   @override
   String get pageTitle => ' ';
+
+  @override
+  List<Faculty> get allFaculties => [];
+
+  @override
+  void didInitDriver() {}
 
   @override
   void didUpdateBuildContext(BuildContext context) {}
 }
 
-class $StudiesPageDriverProvider extends WidgetDriverProvider<StudiesPageDriver> {
+class $FaculitesPageDriverProvider extends WidgetDriverProvider<FaculitesPageDriver> {
   @override
-  StudiesPageDriver buildDriver() {
-    return StudiesPageDriver();
+  FaculitesPageDriver buildDriver() {
+    return FaculitesPageDriver();
   }
 
   @override
-  StudiesPageDriver buildTestDriver() {
-    return _$TestStudiesPageDriver();
+  FaculitesPageDriver buildTestDriver() {
+    return _$TestFaculitesPageDriver();
   }
 }

--- a/feature_modules/studies/lib/src/studies_module.dart
+++ b/feature_modules/studies/lib/src/studies_module.dart
@@ -26,10 +26,10 @@ class StudiesModule extends AppModule
   void provideLocalDependencies() {
     final baseApiClient = GetIt.I.get<BaseApiClient>();
     final studiesStorage = StudiesStorage();
-    final benefitsRepository = StudiesRepository(StudiesApiClient(baseApiClient), studiesStorage);
-    final getFacultiesUsecase = GetFacultiesUsecase(benefitsRepository);
+    final studiesRepository = StudiesRepository(StudiesApiClient(baseApiClient), studiesStorage);
+    final getFacultiesUsecase = GetFacultiesUsecase(studiesRepository);
 
-    GetIt.I.registerSingleton<StudiesRepositoryInterface>(benefitsRepository);
+    GetIt.I.registerSingleton<StudiesRepositoryInterface>(studiesRepository);
     GetIt.I.registerSingleton<GetFacultiesUsecase>(getFacultiesUsecase);
   }
 

--- a/feature_modules/studies/lib/src/studies_module.dart
+++ b/feature_modules/studies/lib/src/studies_module.dart
@@ -1,15 +1,42 @@
+import 'package:core/api.dart';
 import 'package:core/module.dart';
 import 'package:core_routes/studies.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_api/studies.dart';
 
+import 'application/usecase/get_faculties_usecase.dart';
+import 'domain/interface/studies_repository_interface.dart';
+import 'infrastructure/primary/api/faculties_api.dart';
 import 'infrastructure/primary/router/studies_router.dart';
+import 'infrastructure/secondary/data/api/studies_api_client.dart';
+import 'infrastructure/secondary/data/storage/studies_storage.dart';
+import 'infrastructure/secondary/repository/studies_repository.dart';
 
-class StudiesModule extends AppModule with PublicApiProvidingAppModule {
+class StudiesModule extends AppModule
+    with PublicApiProvidingAppModule, WaitingAppStartAppModule, LocalDependenciesProvidingAppModule {
   @override
   String get moduleName => 'StudiesModule';
 
   @override
+  Future onAppStartWaiting() {
+    return GetIt.I.get<GetFacultiesUsecase>().initFaculites();
+  }
+
+  @override
+  void provideLocalDependencies() {
+    final baseApiClient = GetIt.I.get<BaseApiClient>();
+    final studiesStorage = StudiesStorage();
+    final benefitsRepository = StudiesRepository(StudiesApiClient(baseApiClient), studiesStorage);
+    final getFacultiesUsecase = GetFacultiesUsecase(benefitsRepository);
+
+    GetIt.I.registerSingleton<StudiesRepositoryInterface>(benefitsRepository);
+    GetIt.I.registerSingleton<GetFacultiesUsecase>(getFacultiesUsecase);
+  }
+
+  @override
   void providePublicApi() {
+    final getFacultiesUsecase = GetIt.I.get<GetFacultiesUsecase>();
+    GetIt.I.registerSingleton<FacultiesApi>(FacultiesApiImpl(getFacultiesUsecase));
     GetIt.I.registerSingleton<StudiesRouter>(StudiesRouterImpl());
   }
 }

--- a/feature_modules/studies/pubspec.yaml
+++ b/feature_modules/studies/pubspec.yaml
@@ -14,8 +14,11 @@ dependencies:
     path: ../../core
   core_routes:
     path: ../../core_routes
+  shared_api:
+    path: ../../shared_api
   get_it: ^8.0.1
   widget_driver: ^1.0.10
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   json_serializable: ^6.6.2

--- a/l10n/settings/settings_de.arb
+++ b/l10n/settings/settings_de.arb
@@ -37,5 +37,6 @@
   "german": "Deutsch",
   "english": "Englisch",
   "accountDeletionSuccess": "Dein Account und alle zugehörigen Daten wurden erfolgreich gelöscht.",
-  "accountDeletionFailed": "Beim Löschen deines Accounts ist ein Fehler aufgetreten. Bitte versuche es erneut."
+  "accountDeletionFailed": "Beim Löschen deines Accounts ist ein Fehler aufgetreten. Bitte versuche es erneut.",
+  "changeFaculty": "Fakultät ändern"
 }

--- a/l10n/settings/settings_en.arb
+++ b/l10n/settings/settings_en.arb
@@ -148,5 +148,9 @@
   "accountDeletionFailed": "An error occurred while deleting your account. Please try again.",
   "@accountDeletionFailed": {
     "description": "Account deletion failure message"
+  },
+  "changeFaculty": "Change Faculty",
+  "@changeFaculty": {
+    "description": "Change Faculty"
   }
 }

--- a/l10n/studies/studies_de.arb
+++ b/l10n/studies/studies_de.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "de",
   "@@context": "Studies",
-  "studiesTitle": "Studium"
+  "studiesTitle": "Studium",
+  "facultiesTitle": "Fakultäten"
 }

--- a/l10n/studies/studies_en.arb
+++ b/l10n/studies/studies_en.arb
@@ -1,5 +1,6 @@
 {
   "@@locale": "en",
   "@@context": "Studies",
-  "studiesTitle": "Studies"
+  "studiesTitle": "Studies",
+  "facultiesTitle": "Faculites"
 }

--- a/shared_api/lib/src/studies/api/faculties_api.dart
+++ b/shared_api/lib/src/studies/api/faculties_api.dart
@@ -1,0 +1,12 @@
+import '../models/faculty.dart';
+
+abstract class FacultiesApi {
+  /// All faculties available to the user.
+  List<Faculty> get allFaculties;
+
+  /// The list of faculties currently selected by the user
+  List<Faculty> get selectedFaculties;
+
+  /// A stream that emits updates whenever [selectedFaculties] changes.
+  Stream<List<Faculty>> get selectedFacultiesStream;
+}

--- a/shared_api/lib/src/studies/models/faculty.dart
+++ b/shared_api/lib/src/studies/models/faculty.dart
@@ -1,0 +1,9 @@
+abstract class Faculty {
+  const Faculty();
+
+  /// The unique identifier of the faculty.
+  int get id;
+
+  /// The name of the faculty.
+  String get name;
+}

--- a/shared_api/lib/src/studies/studies.dart
+++ b/shared_api/lib/src/studies/studies.dart
@@ -1,0 +1,2 @@
+export 'api/faculties_api.dart';
+export 'models/faculty.dart';

--- a/shared_api/lib/studies.dart
+++ b/shared_api/lib/studies.dart
@@ -1,0 +1,3 @@
+library shared_api.studies;
+
+export 'src/studies/studies.dart';


### PR DESCRIPTION
## 🔗 Related Issue(s)

<!-- Link to any relevant GitHub issues. Use keywords like "Closes #123" or "Fixes #456". -->
- Closes #401]
- Addresses #401]

---

## 🛠️ Type of Change

<!-- Please check the boxes that apply. -->
- [x]✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation update
- [ ] 💅 Style
- [ ] ♻️ Refactor

---

## 📝 Description

Implement faculty selection:
- Faculties are loaded on app start once and cached afterwards
- Faculties can be selected in the settings page (temporary design)
- Selected faculties are cached
- Faculty Information is available through `FacultiesApi`

FaculitesApi:
<img width="540" alt="Screenshot 2025-06-25 at 10 55 17" src="https://github.com/user-attachments/assets/615003c4-54e8-46cb-8788-94e609fb8be0" />

---

## 📸 Screenshots / Videos
Basic Selection Page 
<img src="https://github.com/user-attachments/assets/0edb67c6-cfbb-4217-83cf-946aaea84a8e" alt="" width="250">
---


