### PR TITLE
437 feat implement month enums that are simmilar to the weekday enums using the intl package

### DIFF
--- a/core/lib/src/api/enums/month.dart
+++ b/core/lib/src/api/enums/month.dart
@@ -1,0 +1,65 @@
+import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../../themes.dart';
+
+String get currentLocale => GetIt.I<LanguageProvider>().locale.toString();
+
+enum Month {
+  @JsonValue('JANUARY')
+  january(1),
+  @JsonValue('FEBRUARY')
+  february(2),
+  @JsonValue('MARCH')
+  march(3),
+  @JsonValue('APRIL')
+  april(4),
+  @JsonValue('MAY')
+  may(5),
+  @JsonValue('JUNE')
+  june(6),
+  @JsonValue('JULY')
+  july(7),
+  @JsonValue('AUGUST')
+  august(8),
+  @JsonValue('SEPTEMBER')
+  september(9),
+  @JsonValue('OCTOBER')
+  october(10),
+  @JsonValue('NOVEMBER')
+  november(11),
+  @JsonValue('DECEMBER')
+  december(12);
+
+  const Month(this.value);
+  final int value;
+
+  /// Returns the localized full name of the month (e.g., "January", "Januar", "Gennaio",...).
+  /// But now just calling Month.january or toString() will return the localized name.,
+  /// This is the same as [name] but uses the current locale.
+  @override
+  String toString() => name;
+}
+
+extension MonthToString on Month {
+  // A helper function to get a DateTime object for a specific month.
+  // We can pick any year/day, as only the month matters for formatting.
+  DateTime _getDateTimeForMonth() {
+    return DateTime(2000, value, 1);
+  }
+
+  /// Returns the localized full name of the month (e.g., "January", "Januar", "Gennaio",...).
+  String get name {
+    final fullName = DateFormat.MMMM(currentLocale).format(_getDateTimeForMonth());
+    if (fullName.isEmpty) return fullName;
+    return '${fullName[0].toUpperCase()}${fullName.substring(1)}';
+  }
+
+  /// Returns the localized short name of the month (e.g., "Jan", "Jan", "Gen",...).
+  String get nameShort {
+    final shortName = DateFormat.MMM(currentLocale).format(_getDateTimeForMonth());
+    if (shortName.isEmpty) return shortName;
+    return '${shortName[0].toUpperCase()}${shortName.substring(1)}';
+  }
+}

--- a/core/lib/src/api/enums/weekday.dart
+++ b/core/lib/src/api/enums/weekday.dart
@@ -26,7 +26,7 @@ enum Weekday {
   final int value;
 
   /// Returns the localized full name of the weekday (e.g., "Monday", "Montag", "Lunedi",...).
-  /// But now just calling Weekday.monday.name will return the localized name.,
+  /// But now just calling Weekday.monday or .toString() will return the localized name.,
   /// This is the same as [name] but uses the current locale.
   @override
   String toString() => name;

--- a/core/lib/src/api/enums/weekday.dart
+++ b/core/lib/src/api/enums/weekday.dart
@@ -1,46 +1,62 @@
+import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
 import 'package:json_annotation/json_annotation.dart';
 
-import '../../../localizations.dart';
+import '../../../themes.dart';
+
+String get currentLocale => GetIt.I<LanguageProvider>().locale.toString();
 
 enum Weekday {
   @JsonValue('MONDAY')
-  monday,
+  monday(DateTime.monday),
   @JsonValue('TUESDAY')
-  tuesday,
+  tuesday(DateTime.tuesday),
   @JsonValue('WEDNESDAY')
-  wednesday,
+  wednesday(DateTime.wednesday),
   @JsonValue('THURSDAY')
-  thursday,
+  thursday(DateTime.thursday),
   @JsonValue('FRIDAY')
-  friday,
+  friday(DateTime.friday),
   @JsonValue('SATURDAY')
-  saturday,
+  saturday(DateTime.saturday),
   @JsonValue('SUNDAY')
-  sunday,
+  sunday(DateTime.sunday);
+
+  const Weekday(this.value);
+  final int value;
+
+  /// Returns the localized full name of the weekday (e.g., "Monday", "Montag", "Lunedi",...).
+  /// But now just calling Weekday.monday.name will return the localized name.,
+  /// This is the same as [name] but uses the current locale.
+  @override
+  String toString() => name;
 }
 
 extension WeekdayToString on Weekday {
-  String localizedWeekday(AppLocalizations localizations) {
-    return switch (this) {
-      Weekday.monday => localizations.monday,
-      Weekday.tuesday => localizations.tuesday,
-      Weekday.wednesday => localizations.wednesday,
-      Weekday.thursday => localizations.thursday,
-      Weekday.friday => localizations.friday,
-      Weekday.saturday => localizations.saturday,
-      Weekday.sunday => localizations.sunday,
-    };
+  // A helper function to get a DateTime object for any given year/month/day
+  // that corresponds to the specific weekday. This is needed because
+  // DateFormat.EEEE and DateFormat.E format a DateTime object.
+  // We can pick an arbitrary date where we know the weekday, e.g.,
+  // January 1, 2024 was a Monday.
+  DateTime _getDateTimeForWeekday() {
+    // January 1, 2024 was a Monday (DateTime.monday = 1)
+    final baseDate = DateTime(2024, 1, 1);
+    // Calculate the difference in days from Monday to the current weekday
+    final int daysToAdd = value - DateTime.monday;
+    return baseDate.add(Duration(days: daysToAdd));
   }
 
-  String localizedWeekdayShort(AppLocalizations localizations) {
-    return switch (this) {
-      Weekday.monday => localizations.monday.substring(0, 2),
-      Weekday.tuesday => localizations.tuesday.substring(0, 2),
-      Weekday.wednesday => localizations.wednesday.substring(0, 2),
-      Weekday.thursday => localizations.thursday.substring(0, 2),
-      Weekday.friday => localizations.friday.substring(0, 2),
-      Weekday.saturday => localizations.saturday.substring(0, 2),
-      Weekday.sunday => localizations.sunday.substring(0, 2),
-    };
+  /// Returns the localized full name of the weekday (e.g., "Monday", "Montag", "Lunedi",...).
+  get name {
+    final fullName = DateFormat.EEEE(currentLocale).format(_getDateTimeForWeekday());
+    if (fullName.isEmpty) return fullName;
+    return '${fullName[0].toUpperCase()}${fullName.substring(1)}';
+  }
+
+  /// Returns the localized short name of the weekday (e.g., "Mon", "Mo", "Lu", ...).
+  get nameShort {
+    final shortName = DateFormat.E(currentLocale).format(_getDateTimeForWeekday());
+    if (shortName.isEmpty) return shortName;
+    return '${shortName[0].toUpperCase()}${shortName.substring(1)}';
   }
 }

--- a/feature_modules/cinema/lib/src/util/screening_time.dart
+++ b/feature_modules/cinema/lib/src/util/screening_time.dart
@@ -32,7 +32,7 @@ String getScreeningTime({
       parsedTime.isAfter(startOfWeek) &&
       parsedTime.isBefore(endOfWeek.add(const Duration(days: 1)))) {
     final Weekday weekday = Weekday.values[parsedTime.weekday - 1];
-    return '${weekday.localizedWeekday(context.locals.app)} • ${DateFormat('HH:mm').format(parsedTime)}';
+    return '${weekday.name} • ${DateFormat('HH:mm').format(parsedTime)}';
   }
 
   return DateFormat('dd.MM.yyyy • HH:mm').format(parsedTime);

--- a/feature_modules/libraries/lib/src/widgets/library_status_item.dart
+++ b/feature_modules/libraries/lib/src/widgets/library_status_item.dart
@@ -1,6 +1,5 @@
 import 'package:core/api.dart';
 import 'package:core/components.dart';
-import 'package:core/localizations.dart';
 import 'package:core/themes.dart';
 import 'package:flutter/cupertino.dart';
 
@@ -30,8 +29,8 @@ LmuListItem buildLibraryStatusItem({
   );
 
   return LmuListItem.base(
-    title: isToday ? openingHours.day.localizedWeekday(context.locals.app) : null,
-    subtitle: !isToday ? openingHours.day.localizedWeekday(context.locals.app) : null,
+    title: isToday ? openingHours.day.name : null,
+    subtitle: !isToday ? openingHours.day.name : null,
     trailingArea: timesColumn,
     hasHorizontalPadding: false,
     hasVerticalPadding: false,

--- a/feature_modules/mensa/lib/src/widgets/details/mensa_details_info_section.dart
+++ b/feature_modules/mensa/lib/src/widgets/details/mensa_details_info_section.dart
@@ -116,8 +116,8 @@ class MensaDetailsInfoSection extends StatelessWidget {
     final isToday = DateTime.now().weekday - 1 == index;
 
     return LmuListItem.base(
-      title: isToday ? detail.day.localizedWeekday(appLocalizations) : null,
-      subtitle: !isToday ? detail.day.localizedWeekday(appLocalizations) : null,
+      title: isToday ? detail.day.name : null,
+      subtitle: !isToday ? detail.day.name : null,
       hasVerticalPadding: false,
       hasHorizontalPadding: false,
       trailingTitle: isToday ? '${detail.startTime.substring(0, 5)} - ${detail.endTime.substring(0, 5)}' : null,

--- a/feature_modules/sports/lib/src/widgets/sports_course_tile.dart
+++ b/feature_modules/sports/lib/src/widgets/sports_course_tile.dart
@@ -164,7 +164,7 @@ String formatSportsTimeSlots(AppLocalizations locals, List<SportsTimeSlot> slots
     days.sort((a, b) => a.index.compareTo(b.index));
 
     if (days.length == 1) {
-      return days.first.localizedWeekday(locals);
+      return days.first.name;
     }
 
     final List<List<Weekday>> groupedRanges = [];
@@ -182,8 +182,8 @@ String formatSportsTimeSlots(AppLocalizations locals, List<SportsTimeSlot> slots
 
     return groupedRanges
         .map((group) => group.length > 1
-            ? '${group.first.localizedWeekday(locals)} - ${group.last.localizedWeekday(locals)}' // "Wednesday - Friday"
-            : group.first.localizedWeekday(locals))
+            ? '${group.first.name} - ${group.last.name(locals)}' // "Wednesday - Friday"
+            : group.first.name)
         .join(', ');
   }
 


### PR DESCRIPTION
## 🔗 Related Issue(s)

- Closes #437 
 
---

## 🛠️ Type of Change

<!-- Please check the boxes that apply. -->
- [ x ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation update
- [ ] 💅 Style
- [ ] ♻️ Refactor

---

## 📝 Description

Simply added a localozed month enum that can be used later for the calendar (among other feature_module).

---
